### PR TITLE
fix: fix converting glob expression to regex error

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,8 @@ import pm from 'picomatch'
 export function constructPatternFilter(patterns: string[]): (str: string) => boolean {
   const matchers = patterns.map((glob) => {
     if (glob.match(/[\^$*{}]/)) {
-      const re = pm.toRegex(glob)
+      const { output } = pm.parse(glob)
+      const re = pm.toRegex(output)
       return (str: string) => re.test(str)
     }
     else {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { constructPatternFilter } from '../src/utils'
+
+describe('constructPatternFilter', () => {
+  it('should match exact strings', () => {
+    const filter = constructPatternFilter(['test', 'example'])
+    expect(filter('test')).toBe(true)
+    expect(filter('example')).toBe(true)
+    expect(filter('other')).toBe(false)
+  })
+
+  it('should match patterns with wildcards', () => {
+    const filter = constructPatternFilter(['*.js', '*.ts'])
+    expect(filter('file.js')).toBe(true)
+    expect(filter('file.ts')).toBe(true)
+    expect(filter('file.txt')).toBe(false)
+  })
+
+  it('should match patterns with regex special characters', () => {
+    const filter = constructPatternFilter(['example*'])
+    expect(filter('example123')).toBe(true)
+    expect(filter('test123')).toBe(false)
+  })
+
+  it('should handle empty patterns', () => {
+    const filter = constructPatternFilter([])
+    expect(filter('anything')).toBe(false)
+  })
+
+  it('should match mixed exact strings and patterns', () => {
+    const filter = constructPatternFilter(['test', '*.js'])
+    expect(filter('test')).toBe(true)
+    expect(filter('file.js')).toBe(true)
+    expect(filter('example')).toBe(false)
+  })
+})

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -33,4 +33,21 @@ describe('constructPatternFilter', () => {
     expect(filter('file.js')).toBe(true)
     expect(filter('example')).toBe(false)
   })
+
+  it('should match nested directory patterns', () => {
+    const filter = constructPatternFilter(['src/**/utils', 'test/**/utils'])
+    expect(filter('src/utils')).toBe(true)
+    expect(filter('src/subdir/utils')).toBe(true)
+    expect(filter('test/utils')).toBe(true)
+    expect(filter('test/subdir/utils')).toBe(true)
+    expect(filter('lib/utils')).toBe(false)
+  })
+
+  it('should handle mixed exact and wildcard directory patterns', () => {
+    const filter = constructPatternFilter(['src/utils', 'test/*'])
+    expect(filter('src/utils')).toBe(true)
+    expect(filter('test/utils')).toBe(true)
+    expect(filter('test/other')).toBe(true)
+    expect(filter('src/other')).toBe(false)
+  })
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

fix `constructPatternFilter` fn cannot convert glob expression to regex correctly.

### Linked Issues

N/A

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Also add test cases.