### PR TITLE
feat: replace picocolors with ansis

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,11 +47,11 @@
     "prepare": "simple-git-hooks"
   },
   "dependencies": {
+    "ansis": "^3.12.0",
     "boxen": "^8.0.1",
     "cac": "^6.7.14",
     "cli-progress": "^3.12.0",
     "node-modules-tools": "0.0.0",
-    "picocolors": "^1.1.1",
     "picomatch": "^4.0.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      ansis:
+        specifier: ^3.12.0
+        version: 3.12.0
       boxen:
         specifier: ^8.0.1
         version: 8.0.1
@@ -20,9 +23,6 @@ importers:
       node-modules-tools:
         specifier: 0.0.0
         version: 0.0.0
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
       picomatch:
         specifier: ^4.0.2
         version: 4.0.2
@@ -1104,6 +1104,10 @@ packages:
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
+
+  ansis@3.12.0:
+    resolution: {integrity: sha512-SxhlInpMkv9QCyI2yHyrhVrTF8dH93M/S86DT5f9brFgr92uJLOCg0RNmtx3YKWKcRmNAaU+gyUfHMdUiqxvFw==}
+    engines: {node: '>=14'}
 
   are-docs-informative@0.0.2:
     resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
@@ -3902,6 +3906,8 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@6.2.1: {}
+
+  ansis@3.12.0: {}
 
   are-docs-informative@0.0.2: {}
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,20 +1,20 @@
 import type { PackageModuleType, ResolvedPackageNode } from 'node-modules-tools'
 import process from 'node:process'
+import ansi from 'ansis'
 import boxen from 'boxen'
 import { cac } from 'cac'
 import { Presets, SingleBar } from 'cli-progress'
 import { analyzePackage, listPackageDependencies } from 'node-modules-tools'
-import pc from 'picocolors'
 import { version } from '../package.json'
 import { constructPatternFilter } from './utils'
 
 const cli = cac('are-we-esm')
 
 const colorMap: Record<PackageModuleType, (str: string) => string> = {
-  esm: pc.green,
-  dual: pc.cyan,
-  faux: pc.magenta,
-  cjs: pc.yellow,
+  esm: ansi.green,
+  dual: ansi.cyan,
+  faux: ansi.magenta,
+  cjs: ansi.yellow,
 }
 
 const types = ['esm', 'dual', 'faux', 'cjs'] as PackageModuleType[]
@@ -23,7 +23,7 @@ const nonEsmTypes = ['faux', 'cjs'] as PackageModuleType[]
 function c(type: PackageModuleType, str: string, bold = false): string {
   let colored = colorMap[type](str)
   if (bold)
-    colored = pc.bold(colored)
+    colored = ansi.bold(colored)
   return colored
 }
 
@@ -66,7 +66,7 @@ cli
     const bar = new SingleBar({
       clearOnComplete: true,
       hideCursor: true,
-      format: `{bar} {value}/{total} ${pc.gray('{name}')}`,
+      format: `{bar} {value}/{total} ${ansi.gray('{name}')}`,
       linewrap: false,
       barsize: 40,
     }, Presets.shades_grey)
@@ -101,9 +101,9 @@ cli
       const filtered = resolved.filter(x => x.module === type)
       if (options.list && filtered.length && (options.all || nonEsmTypes.includes(type))) {
         console.log()
-        console.log(pc.inverse(c(type, ` ${type.toUpperCase()} `, true)), c(type, `${filtered.length} packages:`))
+        console.log(ansi.inverse(c(type, ` ${type.toUpperCase()} `, true)), c(type, `${filtered.length} packages:`))
         console.log()
-        console.log(filtered.map(x => `  ${c(type, x.name)}${pc.dim(`@${x.version}`)}`).join('\n'))
+        console.log(filtered.map(x => `  ${c(type, x.name)}${ansi.dim(`@${x.version}`)}`).join('\n'))
       }
       count[type] = filtered.length
     }
@@ -128,28 +128,26 @@ cli
 
         let pkgCountString = ''
         if (total > 1) {
-          pkgCountString = ' '.repeat(5) + Object.entries(pkgCount).map(([type, count]) => c(type as PackageModuleType, String(count)).trim()).join(pc.gray(' | '))
+          pkgCountString = ' '.repeat(5) + Object.entries(pkgCount).map(([type, count]) => c(type as PackageModuleType, String(count)).trim()).join(ansi.gray(' | '))
         }
-        console.log(`\n${c(type, pkg.name)}${pc.dim(`@${pkg.version}`)} ${pkgCountString}`)
+        console.log(`\n${c(type, pkg.name)}${ansi.dim(`@${pkg.version}`)} ${pkgCountString}`)
         for (const dep of deps) {
           if (!options.all && !nonEsmTypes.includes(dep.module))
             continue
-          console.log(` ${pc.dim('|')} ${c(dep.module, dep.name)}${pc.dim(`@${dep.version}`)}`)
+          console.log(` ${ansi.dim('|')} ${c(dep.module, dep.name)}${ansi.dim(`@${dep.version}`)}`)
         }
       }
     }
 
     if (!options.all) {
       console.log()
-      console.log(pc.gray(
-        `Listing non-ESM packages in flat tree, pass ${pc.cyan('--all --list')} to list all packages`,
-      ))
+      console.log(ansi.gray`Listing non-ESM packages in flat tree, pass ${ansi.cyan('--all --list')} to list all packages`)
     }
 
     if (count.cjs || count.faux) {
       console.log()
       console.log(boxen(
-        `  Run ${pc.cyan('pnpm why <package>@<version>')} to find out why you have a package  `,
+        `  Run ${ansi.cyan('pnpm why <package>@<version>')} to find out why you have a package  `,
         {
           borderColor: 'gray',
           borderStyle: 'singleDouble',
@@ -162,7 +160,7 @@ cli
     const esmRatio = (count.dual + count.esm) / resolved.length
     const summary = [
       '',
-      `${pc.blue(pc.bold(String(resolved.length).padStart(8, ' ')))} total packages checked`,
+      `${ansi.blue.bold(String(resolved.length).padStart(8, ' '))} total packages checked`,
       '',
     ]
 
@@ -173,14 +171,14 @@ cli
 
     summary.push(
       '',
-      `${pc.green(pc.bold(`${(esmRatio * 100).toFixed(1)}%`.padStart(8, ' ')))} of packages are ESM-compatible`,
+      `${ansi.green.bold`${(esmRatio * 100).toFixed(1)}%`.padStart(8, ' ')} of packages are ESM-compatible`,
       '',
     )
 
     console.log(boxen(
       summary.join('\n'),
       {
-        title: `${pc.inverse(pc.bold(' Are We ESM? '))} ${pc.dim(`v${version}`)}`,
+        title: `${ansi.inverse.bold` Are We ESM? `} ${ansi.dim`v${version}`}`,
         borderColor: 'gray',
         borderStyle: 'round',
         padding: {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Hello @antfu,

This PR replaces `picocolors` with a better alternative `ansis` that supports both CJS and ESM.
Ansis supports chained syntax for clean and readable code.
Ansis is nearly as small (6.8 kB) as Picocolors (6.4 kB).

## Test


After `pnpm run build` run the app locally compiled to `./dist`, e,g., `node ./dist/cli.mjs ansis`

Outputs:

![image](https://github.com/user-attachments/assets/df4e0cfb-5081-4166-9bb7-21ab1378b2ca)

